### PR TITLE
[Feature] Built and tested a print stylesheet for cleaner page prints.

### DIFF
--- a/themes/wc-eh-docs/assets/scss/eh.scss
+++ b/themes/wc-eh-docs/assets/scss/eh.scss
@@ -3,7 +3,7 @@ $active-nav: #bdeaff;
 $dark: #505050;
 
 
-
+@import 'print';
 @import 'style';
 // Import Bootstrap
 @import "node_modules/bootstrap/scss/bootstrap.scss";
@@ -19,7 +19,6 @@ $dark: #505050;
 @import "node_modules/sweetalert2/dist/sweetalert2.css";
 
 @import "node_modules/highlight.js/scss/a11y-light.scss";
-
 .hljs {
     background: #f7f4f4 !important;
 }

--- a/themes/wc-eh-docs/assets/scss/print.scss
+++ b/themes/wc-eh-docs/assets/scss/print.scss
@@ -1,0 +1,89 @@
+@media print {
+  body {
+    padding-top: 0 !important;
+    overflow: visible;
+    display: -webkit-box;
+    display: -moz-box;
+    display: box !important;
+
+    -webkit-box-orient: vertical;
+    -moz-box-orient: vertical;
+    box-orient: vertical;
+  }
+
+  p,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  div.card {
+    display: block;
+    break-inside: avoid;
+  }
+
+  header {
+    nav {
+      display: none !important;
+    }
+  }
+
+  embed,
+  object,
+  video,
+  audio,
+  #sidebar,
+  .copy-hash {
+    display: none !important;
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  h2.heading,
+  h3.heading {
+    a {
+      text-decoration: none;
+    }
+  }
+
+  div.toc-print {
+    page-break-after: always;
+  }
+
+  div.row.footer-cta,
+  div.scroll-to-top {
+    display: none !important;
+  }
+
+  div.btn-toolbar {
+    .btn-group {
+      display: none !important;
+    }
+  }
+
+  #index-main,
+  #index-main>.row,
+  div.container-fluid,
+  div.container-fluid>.row,
+  div.alert,
+  p,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    display: block;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  @page {
+    margin: 1.75cm 0.5cm;
+  }
+}

--- a/themes/wc-eh-docs/assets/scss/wc.scss
+++ b/themes/wc-eh-docs/assets/scss/wc.scss
@@ -3,6 +3,7 @@ $active-nav: #ffe0bb;
 $dark: #5f6062;
 
 
+@import 'print';
 @import 'style';
 // Import Bootstrap
 @import "node_modules/bootstrap/scss/bootstrap.scss";
@@ -18,7 +19,6 @@ $dark: #5f6062;
 @import "node_modules/sweetalert2/dist/sweetalert2.css";
 
 @import "node_modules/highlight.js/scss/a11y-light.scss";
-
 .hljs {
     background: #f7f4f4 !important;
 }

--- a/themes/wc-eh-docs/layouts/_default/single.html
+++ b/themes/wc-eh-docs/layouts/_default/single.html
@@ -29,14 +29,14 @@
       </div>
       {{ if gt (.TableOfContents | len) 32 }}
       <div class="row flex-column-reverse flex-xl-row">
-        <div class="col-12 col-xl-8">
-          {{ .Content | safeHTML }}
-        </div>
-        <div class="col-12 col-xl-4">
+        <div class="col-12 col-xl-4 toc-print order-2">
           <h2>Covered by this topic</h2>
           <aside>
             {{ .TableOfContents | replaceRE `href="#(.*)"` (printf `href="%s#%s"` .Page.RelPermalink "$1") | safeHTML }}
           </aside>
+        </div>
+        <div class="col-12 col-xl-8 content-print order-1">
+          {{ .Content | safeHTML }}
         </div>
       </div>
       {{ else }}

--- a/themes/wc-eh-docs/layouts/partials/footer-call-to-action.html
+++ b/themes/wc-eh-docs/layouts/partials/footer-call-to-action.html
@@ -1,5 +1,5 @@
 <hr />
-<div class="row">
+<div class="row footer-cta">
     <div class="col-12 col-md-6">
         <h5>Did this doc help you?</h5>
         <p>

--- a/themes/wc-eh-docs/layouts/partials/header.html
+++ b/themes/wc-eh-docs/layouts/partials/header.html
@@ -26,7 +26,7 @@
   {{ $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true "precision" 6 "includePaths" (slice "node_modules")) }}
   {{ $style := resources.Get $themestylepath | resources.ToCSS $options | resources.PostCSS (dict "config" "postcss.config.js") | resources.Minify |  resources.Fingerprint "sha512" }}
 
-  <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}" media="screen">
+  <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
 
   {{ if gt (len (split .RelPermalink "/") ) 2 }}
   <!-- Breadcrumbs LD+JSON https://developers.google.com/search/docs/advanced/structured-data/breadcrumb#json-ld -->


### PR DESCRIPTION
**Description**
This PR imports a new print stylesheet which trims unnecessary elements and restyles irrelevant decoration for a clean print/pdf view of a given document. By default if the page's Table of Contents exists it will claim at least the first page of the print document with a page-break after and therein create a better reading experience. The document metadata will continue to occupy the space following all content. This information is valuable for record keeping when using print material (dates/changes/etc.) 

![docs_print](https://user-images.githubusercontent.com/97115745/200914537-b8ee2a3e-72ea-40c0-bbbc-8da58a06a355.gif)
