### PR TITLE
Bug: Object tags in markdown break the DOM when parsed

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -29,8 +29,8 @@ This documentation is organized into two sections "Programs" and "Functions."  T
 
 {{% system-name %}} offers various solutions for Enterprise Management of Health and Wellness. Check out our clinical and corporate solutions intended to streamline operations, reduce burden, and increase overall quality.  Programs are listed in yellow and some functions are highlighted below each program.
 
-  
-<object type="image/svg+xml" data="diagrams/eh-positioning.svg" />  
+<!-- There is a parsing error with <object ...> tags, which had been used here, for now image markdown must be used or things will break on the main landing route -->
+![](diagrams/eh-positioning.svg)
 
 
 {{% /only %}}

--- a/content/functions/injury-care.md
+++ b/content/functions/injury-care.md
@@ -22,8 +22,8 @@ menu:
 
 {{% system-name %}} can be used for treating, documenting, managing, *and* reporting injuries and illnesses, which can be initiated from a visit to the clinic, or in advance, via an employee portal. This allows incidents to be reported anytime, day or night. And regardless of how the information is captured, {{% system-name %}} can compile the recorded data into form overlays, minimizing the need for redundant data entry, while also easing reporting burdens. Overall, {{% system-name %}} not only incorporates streamlined processes for recording and treating injuries and illnesses, it also provides tools for easy tracking and follow-up through the use of its integrated worklists and tasking module.
 
-  
-<object type="image/svg+xml" data="../diagrams/injury-care.svg" />  
+<!-- injury-care.svg does not exist at this path! -->
+<!-- ![](../diagrams/injury-care.svg)   -->
 
 
   


### PR DESCRIPTION
Offenders (2) have been converted to image markdown or removed because they don't exist at the path being requested. In this case, elements were not rendered in the page after the bad parse, breaking critical search functionality when on the EH Docs startpage.

**Was:**
![Object Tag](https://user-images.githubusercontent.com/97115745/216682710-4469880f-7446-4cea-950d-8112436f7d50.png)

All content attempting to load after the `<object ... />` tag is dropped by the browser and therefore the search-results element is not loaded or available when called if a search is performed on a route with an offending object tag.

**Is now:**
![Image Markdown](https://user-images.githubusercontent.com/97115745/216683160-6813cb82-60d8-425e-8472-099027123ef6.png)

