### PR TITLE
Fix shortcode in list item

### DIFF
--- a/themes/wc-eh-docs/layouts/shortcodes/system-name.html
+++ b/themes/wc-eh-docs/layouts/shortcodes/system-name.html
@@ -1,3 +1,1 @@
-{{ if $.Site.Params.Brand.name }}
-<span class="brand-name">{{ $.Site.Params.Brand.name }}</span>
-{{ end }} 
+{{ if $.Site.Params.Brand.name }}<span class="brand-name">{{ $.Site.Params.Brand.name }}</span>{{ end }}


### PR DESCRIPTION
For some reason shortcode must be defined in single line to appear in the list item correctly

Fixes:
https://github.com/mieweb/wikiGDrive/issues/542#issuecomment-2643826197
![image](https://github.com/user-attachments/assets/0aec799f-396c-4dd6-b9b8-6880eb951303)
