### PR TITLE
standardize HTML indentation in info, note, tip, and warning shortcodes.

### DIFF
--- a/themes/wc-eh-docs/layouts/shortcodes/note.html
+++ b/themes/wc-eh-docs/layouts/shortcodes/note.html
@@ -1,4 +1,4 @@
 <div class="alert alert-dark p-0 mb-3 card notice note">
-    <div class="card-header"><i class="fa-solid fa-note-sticky fa-lg me-2" aria-hidden="true"></i> Note</div>
-    <div class="card-body">{{ .Inner | markdownify }}</div>
+  <div class="card-header"><i class="fa-solid fa-note-sticky fa-lg me-2" aria-hidden="true"></i> Note</div>
+  <div class="card-body">{{ .Inner | markdownify }}</div>
 </div>

--- a/themes/wc-eh-docs/layouts/shortcodes/tip.html
+++ b/themes/wc-eh-docs/layouts/shortcodes/tip.html
@@ -1,4 +1,4 @@
 <div class="alert alert-success p-0 mb-3 card notice tip">
-    <div class="card-header"><i class="fa-solid fa-lightbulb fa-lg me-2" aria-hidden="true"></i> Tip</div>
-    <div class="card-body">{{ .Inner | markdownify }}</div>
+  <div class="card-header"><i class="fa-solid fa-lightbulb fa-lg me-2" aria-hidden="true"></i> Tip</div>
+  <div class="card-body">{{ .Inner | markdownify }}</div>
 </div>

--- a/themes/wc-eh-docs/layouts/shortcodes/warning.html
+++ b/themes/wc-eh-docs/layouts/shortcodes/warning.html
@@ -1,8 +1,4 @@
 <div class="alert alert-warning p-0 mb-3 card notice warning">
-  <div class="card-header">
-    <i class="fa-solid fa-exclamation-triangle fa-lg me-2" aria-hidden="true"></i> Warning
-  </div>
-  <div class="card-body">
-    {{ .Inner | markdownify }}
-  </div>
+  <div class="card-header"><i class="fa-solid fa-exclamation-triangle fa-lg me-2" aria-hidden="true"></i> Warning</div>
+  <div class="card-body">{{ .Inner | markdownify }}</div>
 </div>


### PR DESCRIPTION
 'Pandoc' markup used to break the rendering of these elements

UPDATES Document text flowing into Navigation Pane #82 
UPDATES Notes/Tips Seem to be Broken #84