### PR TITLE
Remove 'Additional Capabilities' section from Ozwell AI Assistant docs

### DIFF
--- a/content/functions/artificial-intelligence/ozwell-ai-assistant.md
+++ b/content/functions/artificial-intelligence/ozwell-ai-assistant.md
@@ -77,6 +77,7 @@ ___
 
 ![](./ozwell-ai-assistant.assets/55a0516032703cb463bd4325e9f05d0a.png)
 
+* **Important**: These are experimental features. Always verify the accuracy of extracted data before saving, as AI systems may occasionally generate incorrect information.
 * Click the magic wand icon to analyze the transcribed information.
 
 ![](./ozwell-ai-assistant.assets/46ef44ca9f807c2beeace1f624bbdde2.png)

--- a/content/functions/artificial-intelligence/ozwell-ai-assistant.md
+++ b/content/functions/artificial-intelligence/ozwell-ai-assistant.md
@@ -137,14 +137,7 @@ ___
 
 ___
 
-## 8. Additional Capabilities (In Development)
-
-* Automated Voice Response: Call-in system for incident reporting and case creation.
-* AI-Driven Report Generation: Request custom reports by specifying the data needed.
-
-___
-
-## 9. Tips for Effective Use
+## 8. Tips for Effective Use
 
 * Always review and edit generated documents before finalizing.
 * Use the image upload feature for any paper-based or device-generated data.


### PR DESCRIPTION
Removed the 'Additional Capabilities (In Development)' section from the Ozwell AI Assistant documentation as these features don't have a confirmed release date and shouldn't be promoted yet.

Changes:
- Removed section 8 about features in development
- Renumbered 'Tips for Effective Use' from section 9 to section 8