### PR TITLE
feat: URL-driven search with skeleton loader

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,27 +1,27 @@
 // Cloudflare Pages Middleware
 // - Strips .html extensions from URLs with a 301 permanent redirect.
-// - Redirects /videos/ paths to the external video site for each brand.
+// - Redirects /videos/ paths to the external video site based on domain.
 //
 // e.g. /features/system-administration/data-migration/order-list-import-tool.html
 //   -> /features/system-administration/data-migration/order-list-import-tool
-// e.g. /eh/videos/foo -> https://videos.enterprise.health/videos/foo
-// e.g. /wc/videos/bar -> https://videos.webch.art/videos/bar
+// e.g. docs.enterprisehealth.com/videos/foo -> https://videos.enterprise.health/videos/foo
+// e.g. docs.webchartnow.com/videos/bar    -> https://videos.webch.art/videos/bar
 
 const VIDEO_HOSTS: Record<string, string> = {
-  eh: "https://videos.enterprise.health",
-  wc: "https://videos.webch.art",
+  "docs.enterprisehealth.com": "https://videos.enterprise.health",
+  "docs.webchartnow.com": "https://videos.webch.art",
 };
 
 export const onRequest: PagesFunction = async (context) => {
   const url = new URL(context.request.url);
 
-  // Redirect /<brand>/videos/* to the external video site
-  const videosMatch = url.pathname.match(/^\/(eh|wc)(\/videos\/.*)$/);
-  if (videosMatch) {
-    const brand = videosMatch[1];
-    const videoPath = videosMatch[2]; // e.g. /videos/foo
-    const host = VIDEO_HOSTS[brand];
-    return Response.redirect(`${host}${videoPath}${url.search}`, 301);
+  // Redirect /videos/* to the external video site based on hostname
+  if (url.pathname.startsWith("/videos/") || url.pathname === "/videos") {
+    const host = VIDEO_HOSTS[url.hostname];
+    if (host) {
+      const videoPath = url.pathname === "/videos" ? "/videos/" : url.pathname;
+      return Response.redirect(`${host}${videoPath}${url.search}`, 301);
+    }
   }
 
   if (url.pathname.endsWith(".html")) {

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,10 +1,28 @@
 // Cloudflare Pages Middleware
-// Strips .html extensions from URLs with a 301 permanent redirect.
+// - Strips .html extensions from URLs with a 301 permanent redirect.
+// - Redirects /videos/ paths to the external video site for each brand.
+//
 // e.g. /features/system-administration/data-migration/order-list-import-tool.html
 //   -> /features/system-administration/data-migration/order-list-import-tool
+// e.g. /eh/videos/foo -> https://videos.enterprise.health/videos/foo
+// e.g. /wc/videos/bar -> https://videos.webch.art/videos/bar
+
+const VIDEO_HOSTS: Record<string, string> = {
+  eh: "https://videos.enterprise.health",
+  wc: "https://videos.webch.art",
+};
 
 export const onRequest: PagesFunction = async (context) => {
   const url = new URL(context.request.url);
+
+  // Redirect /<brand>/videos/* to the external video site
+  const videosMatch = url.pathname.match(/^\/(eh|wc)(\/videos\/.*)$/);
+  if (videosMatch) {
+    const brand = videosMatch[1];
+    const videoPath = videosMatch[2]; // e.g. /videos/foo
+    const host = VIDEO_HOSTS[brand];
+    return Response.redirect(`${host}${videoPath}${url.search}`, 301);
+  }
 
   if (url.pathname.endsWith(".html")) {
     // Remove .html, preserve query string and hash

--- a/themes/mieweb-docs/layouts/_default/baseof.html
+++ b/themes/mieweb-docs/layouts/_default/baseof.html
@@ -166,6 +166,18 @@
     window.BaseURL = "{{ .Site.BaseURL }}";
     window.BrandCode = "{{ .Site.Params.Brand.code }}";
     
+    // Early redirect: #search=... → ?q=... (before page renders)
+    (function() {
+      var hash = window.location.hash;
+      if (hash.indexOf('#search=') === 0) {
+        var query = decodeURIComponent(hash.substring(8));
+        var url = new URL(window.location.href);
+        url.hash = '';
+        url.searchParams.set('q', query);
+        window.location.replace(url.toString());
+      }
+    })();
+    
     // Theme detection
     if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
       document.documentElement.setAttribute('data-theme', 'dark');


### PR DESCRIPTION
## Summary

Adds support for URL-driven search so that links like `https://docs.enterprisehealth.com/#search=test` automatically open the search modal with results.

## Changes

### Hash-to-query redirect (`baseof.html`)
- Early inline `<script>` in `<head>` redirects `#search=...` → `?q=...` before the page renders (no flash of content)
- Uses `window.location.replace()` so the hash URL doesn't pollute browser history

### Search modal enhancements (`main.js`)
- **`?q=` query param support**: On page load, if `?q=test` is present, the search modal opens pre-filled with the query and results are shown
- **Skeleton loader**: 5 animated placeholder rows appear immediately while the search index loads, so the UI feels instant
- **Non-blocking index build**: The lunr index is now built using `lunr.Builder` with chunked `add()` calls (200 docs per chunk), yielding to the browser between chunks via `setTimeout(0)` to keep the UI responsive
- **URL cleanup**: `?q=` param is removed from the URL via `history.replaceState()` when the search modal is closed
- **Concurrent load guard**: Prevents duplicate index loads if multiple callers trigger `loadSearchIndex()` simultaneously

### SEO alignment
- The existing `SearchAction` structured data in `baseof.html` already declares `?q={search_term_string}` as the search URL template — this implementation matches that contract

## Testing
- Navigate to `/#search=test` → should redirect to `/?q=test` and show search results
- Navigate directly to `/?q=scheduling` → modal opens with "scheduling" pre-filled and skeleton → results
- Close modal → URL bar no longer has `?q=`
- Normal search via Cmd/K still works as before