### PR TITLE
feat: auto-install pandoc in build.sh for Cloudflare Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ git.json
 config/_default/menu.en.json
 .hugo_build.lock
 .idea
+.pandoc/
 .playwright-mcp/
 .wrangler/

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,58 @@
 #!/bin/bash
 set -eo pipefail
 
+PANDOC_VERSION="3.6.4"
+
+# Ensure pandoc is available (required by some markdown files using markup: 'pandoc')
+ensure_pandoc() {
+  if command -v pandoc &>/dev/null; then
+    echo "pandoc found: $(pandoc --version | head -1)"
+    return
+  fi
+
+  echo "pandoc not found, downloading v${PANDOC_VERSION}..."
+  local os arch tarball url
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64)  tarball="pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" ;;
+        aarch64) tarball="pandoc-${PANDOC_VERSION}-linux-arm64.tar.gz" ;;
+        *) echo "Unsupported Linux arch: $arch"; return 1 ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64)  tarball="pandoc-${PANDOC_VERSION}-x86_64-macOS.zip" ;;
+        arm64)   tarball="pandoc-${PANDOC_VERSION}-arm64-macOS.zip" ;;
+        *) echo "Unsupported macOS arch: $arch"; return 1 ;;
+      esac
+      ;;
+    *) echo "Unsupported OS: $os"; return 1 ;;
+  esac
+
+  url="https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/${tarball}"
+  local pandoc_dir="${PANDOC_DIR:-.pandoc}"
+  mkdir -p "$pandoc_dir"
+
+  if [[ "$tarball" == *.tar.gz ]]; then
+    wget -qO- "$url" | tar xz --strip-components=1 -C "$pandoc_dir"
+  else
+    local tmpzip
+    tmpzip="$(mktemp)"
+    wget -qO "$tmpzip" "$url"
+    unzip -qo "$tmpzip" -d "$pandoc_dir"
+    rm -f "$tmpzip"
+  fi
+
+  export PATH="$pandoc_dir/bin:$PATH"
+  echo "pandoc installed: $(pandoc --version | head -1)"
+}
+
+ensure_pandoc
+
 HUGO_RUN=""
 OPTS=""
 BASE_URL="/"

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,71 @@ set -eo pipefail
 
 PANDOC_VERSION="3.6.4"
 
+# Get SHA256 checksum for a pandoc release artifact (verified from GitHub releases)
+get_pandoc_sha256() {
+  case "$1" in
+    pandoc-3.6.4-linux-amd64.tar.gz)  echo "5def6e1ff535e397becce292ee97767a947306150b9fb1488003b67ac3417c5e" ;;
+    pandoc-3.6.4-linux-arm64.tar.gz)  echo "ad5cf63fe0420388d9ec513f02d03e061477b786d11a328164dce8ad7387b8bd" ;;
+    pandoc-3.6.4-x86_64-macOS.zip)    echo "35789fb4afc61266b954035059820dd546b10d8f05fef36a8deadffaedffc2b8" ;;
+    pandoc-3.6.4-arm64-macOS.zip)     echo "88af17f1885afacb25f70ce4c8c44428feb6da860b6cf690e30da77998456c7f" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Download a URL to stdout or to a file, using curl or wget (whichever is available)
+download() {
+  local url="$1" dest="${2:-}"
+  if command -v curl &>/dev/null; then
+    if [[ -n "$dest" ]]; then
+      curl -fsSL -o "$dest" "$url"
+    else
+      curl -fsSL "$url"
+    fi
+  elif command -v wget &>/dev/null; then
+    if [[ -n "$dest" ]]; then
+      wget -qO "$dest" "$url"
+    else
+      wget -qO- "$url"
+    fi
+  else
+    echo "Error: neither 'curl' nor 'wget' is installed. Please install one to download pandoc." >&2
+    return 1
+  fi
+}
+
+# Verify SHA256 checksum of a file
+verify_checksum() {
+  local file="$1" expected="$2" actual
+  if command -v sha256sum &>/dev/null; then
+    actual="$(sha256sum "$file" | cut -d' ' -f1)"
+  elif command -v shasum &>/dev/null; then
+    actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+  else
+    echo "Warning: no sha256sum or shasum available, skipping checksum verification" >&2
+    return 0
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Error: checksum mismatch for $(basename "$file")" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    return 1
+  fi
+}
+
 # Ensure pandoc is available (required by some markdown files using markup: 'pandoc')
 ensure_pandoc() {
+  local pandoc_dir="${PANDOC_DIR:-.pandoc}"
+
+  # Check if pandoc is already on PATH
   if command -v pandoc &>/dev/null; then
     echo "pandoc found: $(pandoc --version | head -1)"
+    return
+  fi
+
+  # Check if pandoc exists in the cached install directory
+  if [[ -x "$pandoc_dir/bin/pandoc" ]]; then
+    export PATH="$pandoc_dir/bin:$PATH"
+    echo "pandoc found (cached): $(pandoc --version | head -1)"
     return
   fi
 
@@ -18,40 +79,67 @@ ensure_pandoc() {
   case "$os" in
     Linux)
       case "$arch" in
-        x86_64)  tarball="pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" ;;
-        aarch64) tarball="pandoc-${PANDOC_VERSION}-linux-arm64.tar.gz" ;;
-        *) echo "Unsupported Linux arch: $arch"; return 1 ;;
+        x86_64)           tarball="pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz" ;;
+        aarch64|arm64)    tarball="pandoc-${PANDOC_VERSION}-linux-arm64.tar.gz" ;;
+        *) echo "Unsupported Linux arch: $arch" >&2; return 1 ;;
       esac
       ;;
     Darwin)
       case "$arch" in
         x86_64)  tarball="pandoc-${PANDOC_VERSION}-x86_64-macOS.zip" ;;
         arm64)   tarball="pandoc-${PANDOC_VERSION}-arm64-macOS.zip" ;;
-        *) echo "Unsupported macOS arch: $arch"; return 1 ;;
+        *) echo "Unsupported macOS arch: $arch" >&2; return 1 ;;
       esac
       ;;
-    *) echo "Unsupported OS: $os"; return 1 ;;
+    *) echo "Unsupported OS: $os" >&2; return 1 ;;
   esac
 
   url="https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/${tarball}"
-  local pandoc_dir="${PANDOC_DIR:-.pandoc}"
+  local expected_sha
+  expected_sha="$(get_pandoc_sha256 "$tarball")"
   mkdir -p "$pandoc_dir"
 
   if [[ "$tarball" == *.tar.gz ]]; then
-    wget -qO- "$url" | tar xz --strip-components=1 -C "$pandoc_dir"
+    local tmptgz
+    tmptgz="$(mktemp)"
+    download "$url" "$tmptgz"
+    verify_checksum "$tmptgz" "$expected_sha"
+    tar xz --strip-components=1 -C "$pandoc_dir" < "$tmptgz"
+    rm -f "$tmptgz"
   else
+    if ! command -v unzip &>/dev/null; then
+      echo "Error: 'unzip' is required to install pandoc from ZIP archives." >&2
+      return 1
+    fi
     local tmpzip
     tmpzip="$(mktemp)"
-    wget -qO "$tmpzip" "$url"
+    download "$url" "$tmpzip"
+    verify_checksum "$tmpzip" "$expected_sha"
     unzip -qo "$tmpzip" -d "$pandoc_dir"
     rm -f "$tmpzip"
+    # macOS ZIPs extract into a nested directory (e.g. pandoc-3.6.4-arm64/)
+    # Move contents up so $pandoc_dir/bin/pandoc exists
+    local nested_dir
+    nested_dir="$(find "$pandoc_dir" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    if [[ -n "$nested_dir" && -d "$nested_dir/bin" ]]; then
+      mv "$nested_dir"/* "$pandoc_dir"/
+      rmdir "$nested_dir"
+    fi
   fi
 
   export PATH="$pandoc_dir/bin:$PATH"
   echo "pandoc installed: $(pandoc --version | head -1)"
 }
 
-ensure_pandoc
+# Only ensure pandoc when a Hugo target (wc or eh) is specified
+for arg in "$@"; do
+  case "$arg" in
+    wc|eh)
+      ensure_pandoc
+      break
+      ;;
+  esac
+done
 
 HUGO_RUN=""
 OPTS=""


### PR DESCRIPTION
## Problem

15 markdown files (synced from Google Drive via WikiGDrive) declare `markup: 'pandoc'` in their front matter. This tells Hugo to use pandoc as an external renderer — required for pandoc-specific features like lettered sub-lists (`a.`, `b.`, `c.` → `<ol type="a">`).

Pandoc is **not available** in the Cloudflare Pages build environment, causing these pages to fail rendering.

## Solution

Add an `ensure_pandoc()` function to `build.sh` that runs before Hugo:

- **Skips download** if pandoc is already on `$PATH` (local dev, self-hosted runners)
- **Downloads pandoc 3.6.4** static binary from GitHub releases when not found
- **Detects OS/arch** automatically: Linux amd64/arm64, macOS x86_64/arm64
- **Extracts to `.pandoc/`** and prepends to `$PATH`
- **`$PANDOC_DIR` env var** allows CI to override the install location for caching

Also adds `.pandoc/` to `.gitignore`.

## Affected files with `markup: 'pandoc'`

<details>
<summary>15 files</summary>

- `content/resources/intro-to-the-system/system-anatomy.md`
- `content/rapid-deployment/review-sessions/review-session-pre-placement.md`
- `content/features/system-administration/interfaces/outbound-interface-install-instructions.md`
- `content/features/system-administration/interfaces/query-odg-integration.md`
- `content/features/system-administration/system-controls/new-provider-configuration-recommendations.md`
- `content/features/document-management/scanning-and-indexing/scanner-cleaning.md`
- `content/features/document-management/imaging/inbound-application-installation-dicomd.md`
- `content/features/system-administration/system-controls/terminated-provider-configuration-recommendations.md`
- `content/features/financial-functionality/viewing-expired-fee-schedules.md`
- `content/features/quality-of-care/measures/quality-measure-specifications-and-recommended-workflows/cms-165-controlling-high-blood-pressure.md`
- `content/features/document-management/send-document.md`
- `content/features/quality-of-care/measures/quality-measure-specifications-and-recommended-workflows/cms-122-diabetes-hemoglobin-a1c-hba1c-poor-control-greater9.md`
- `content/features/quality-of-care/measures/quality-measure-specifications-and-recommended-workflows/cms-124-cervical-cancer-screening.md`
- `content/features/quality-of-care/measures/quality-measure-specifications-and-recommended-workflows/cms-2-preventive-care-and-screening-screening-for-depression-and-follow-up-plan-workflow.md`
- `content/features/fax-manager/incoming-file-fax-q-set-up-and-documentation.md`

</details>

## Testing

- Verified locally: `./build.sh eh` completes successfully (1942 pages)
- Confirmed pandoc-rendered pages produce correct HTML (e.g., `<ol type="a">` for lettered sub-lists)


<img width="1116" height="473" alt="Screenshot 2026-03-24 at 11 08 40 AM" src="https://github.com/user-attachments/assets/8b95a918-825d-4ef8-8b09-6b31a28b7c06" />


