### PR TITLE
Fix pandoc directory path assignment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ verify_checksum() {
 
 # Ensure pandoc is available (required by some markdown files using markup: 'pandoc')
 ensure_pandoc() {
-  local pandoc_dir="${PANDOC_DIR:-.pandoc}"
+  local pandoc_dir="${PANDOC_DIR:-"$PWD/.pandoc"}"
 
   # Check if pandoc is already on PATH
   if command -v pandoc &>/dev/null; then


### PR DESCRIPTION
This pull request makes a small change to the way the `pandoc_dir` variable is set in the `ensure_pandoc()` function in `build.sh`. The change ensures that the default `.pandoc` directory is always resolved relative to the current working directory.